### PR TITLE
Add Dynasty Cup WordPress theme

### DIFF
--- a/dynastycup-theme/footer.php
+++ b/dynastycup-theme/footer.php
@@ -1,0 +1,7 @@
+    </main>
+    <footer>
+        <p>&copy; <?php echo date( 'Y' ); ?> Dynasty Cup</p>
+    </footer>
+    <?php wp_footer(); ?>
+</body>
+</html>

--- a/dynastycup-theme/functions.php
+++ b/dynastycup-theme/functions.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Funzioni principali del tema Dynasty Cup
+ */
+
+// Aggiunge supporto per Elementor e altre funzionalità
+function dynastycup_setup() {
+    add_theme_support( 'title-tag' );
+    add_theme_support( 'post-thumbnails' );
+    add_theme_support( 'custom-logo' );
+}
+add_action( 'after_setup_theme', 'dynastycup_setup' );
+
+// Enqueue di script e stili
+function dynastycup_scripts() {
+    wp_enqueue_style( 'dynastycup-style', get_stylesheet_uri(), array(), '1.0' );
+    wp_enqueue_script( 'dynastycup-countdown', get_template_directory_uri() . '/js/countdown.js', array('jquery'), '1.0', true );
+}
+add_action( 'wp_enqueue_scripts', 'dynastycup_scripts' );
+

--- a/dynastycup-theme/header.php
+++ b/dynastycup-theme/header.php
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?> >
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?> >
+    <header>
+        <?php if ( has_custom_logo() ) : ?>
+            <div class="site-logo">
+                <?php the_custom_logo(); ?>
+            </div>
+        <?php else : ?>
+            <h1 class="site-title"><?php bloginfo( 'name' ); ?></h1>
+        <?php endif; ?>
+    </header>
+    <main>

--- a/dynastycup-theme/js/countdown.js
+++ b/dynastycup-theme/js/countdown.js
@@ -1,0 +1,22 @@
+(function($){
+    $(document).ready(function(){
+        var endDate = new Date('2024-12-31T00:00:00'); // Data fittizia del torneo
+        var countdownEl = $('#dynasty-countdown');
+        if(!countdownEl.length){ return; }
+        function updateCountdown(){
+            var now = new Date();
+            var diff = endDate - now;
+            if(diff <= 0){
+                countdownEl.text('Il torneo è iniziato!');
+                clearInterval(timer);
+                return;
+            }
+            var days = Math.floor(diff / (1000*60*60*24));
+            var hours = Math.floor((diff / (1000*60*60)) % 24);
+            var minutes = Math.floor((diff / (1000*60)) % 60);
+            countdownEl.text(days + 'g ' + hours + 'h ' + minutes + 'm');
+        }
+        updateCountdown();
+        var timer = setInterval(updateCountdown, 60000);
+    });
+})(jQuery);

--- a/dynastycup-theme/page-home.php
+++ b/dynastycup-theme/page-home.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Template Name: Home
+ */
+get_header();
+?>
+<section class="home-hero">
+    <h2>Benvenuti alla Dynasty Cup</h2>
+    <div class="countdown" id="dynasty-countdown"></div>
+    <a href="#iscriviti" class="cta-button">Iscriviti Ora</a>
+</section>
+<?php
+get_footer();

--- a/dynastycup-theme/page-partite.php
+++ b/dynastycup-theme/page-partite.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Template Name: Partite
+ */
+get_header();
+?>
+<section class="partite">
+    <h2>Calendario Partite</h2>
+    <?php
+    // Esempio di calendario diviso per giorno
+    $giorni = array(
+        'Giorno 1' => array(
+            array('ora' => '10:00', 'match' => 'Squadra A vs Squadra B'),
+            array('ora' => '14:00', 'match' => 'Squadra C vs Squadra D'),
+        ),
+        'Giorno 2' => array(
+            array('ora' => '10:00', 'match' => 'Squadra E vs Squadra F'),
+            array('ora' => '14:00', 'match' => 'Squadra G vs Squadra H'),
+        ),
+    );
+    foreach ( $giorni as $giorno => $partite ) :
+    ?>
+        <h3><?php echo esc_html( $giorno ); ?></h3>
+        <ul>
+        <?php foreach ( $partite as $p ) : ?>
+            <li><?php echo esc_html( $p['ora'] . ' - ' . $p['match'] ); ?></li>
+        <?php endforeach; ?>
+        </ul>
+    <?php endforeach; ?>
+</section>
+<?php
+get_footer();

--- a/dynastycup-theme/page-regolamento.php
+++ b/dynastycup-theme/page-regolamento.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Template Name: Regolamento
+ */
+get_header();
+?>
+<section class="regolamento">
+    <h2>Regolamento</h2>
+    <details>
+        <summary>Articolo 1 - Iscrizione</summary>
+        <p>Informazioni sull'iscrizione al torneo.</p>
+    </details>
+    <details>
+        <summary>Articolo 2 - Punteggi</summary>
+        <p>Regole sui punteggi e la classifica.</p>
+    </details>
+    <details>
+        <summary>Articolo 3 - Fair Play</summary>
+        <p>Norme di comportamento e fair play.</p>
+    </details>
+</section>
+<?php
+get_footer();

--- a/dynastycup-theme/page-risultati.php
+++ b/dynastycup-theme/page-risultati.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Template Name: Risultati
+ */
+get_header();
+?>
+<section class="risultati">
+    <h2>Risultati</h2>
+    <table class="table-dynasty">
+        <thead>
+            <tr>
+                <th>Partita</th>
+                <th>Punteggio</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php
+            // Esempio di dati, in pratica potrebbero essere recuperati dal database
+            $risultati = array(
+                array('match' => 'Squadra A vs Squadra B', 'score' => '2 - 1'),
+                array('match' => 'Squadra C vs Squadra D', 'score' => '0 - 0'),
+            );
+            foreach ( $risultati as $r ) :
+            ?>
+            <tr>
+                <td><?php echo esc_html( $r['match'] ); ?></td>
+                <td><?php echo esc_html( $r['score'] ); ?></td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</section>
+<?php
+get_footer();

--- a/dynastycup-theme/page-squadre.php
+++ b/dynastycup-theme/page-squadre.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Template Name: Squadre e Gironi
+ */
+get_header();
+?>
+<section class="squadre">
+    <h2>Squadre e Gironi</h2>
+    <table class="table-dynasty">
+        <thead>
+            <tr>
+                <th>Girone</th>
+                <th>Squadra</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php
+            // Array di esempio per la generazione dinamica
+            $gironi = array(
+                'A' => array('Squadra A', 'Squadra B'),
+                'B' => array('Squadra C', 'Squadra D'),
+            );
+            foreach ( $gironi as $girone => $squadre ) :
+                foreach ( $squadre as $squadra ) :
+            ?>
+            <tr>
+                <td><?php echo esc_html( $girone ); ?></td>
+                <td><?php echo esc_html( $squadra ); ?></td>
+            </tr>
+            <?php
+                endforeach;
+            endforeach;
+            ?>
+        </tbody>
+    </table>
+</section>
+<?php
+get_footer();

--- a/dynastycup-theme/style.css
+++ b/dynastycup-theme/style.css
@@ -1,0 +1,63 @@
+/*
+Theme Name: Dynasty Cup
+Theme URI: https://example.com/dynastycup
+Author: Codex
+Description: Tema WordPress personalizzato per il torneo di calcio "Dynasty Cup".
+Version: 1.0
+Tags: custom-theme, tournament, dynasty-cup
+Text Domain: dynastycup
+*/
+
+/* Base styling */
+body {
+    font-family: Arial, sans-serif;
+    background-color: #000;
+    color: #d4af37;
+    margin: 0;
+    padding: 0;
+}
+
+a {
+    color: #d4af37;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+header, footer {
+    background-color: #111;
+    padding: 20px;
+    text-align: center;
+}
+
+.cta-button {
+    background-color: #d4af37;
+    color: #000;
+    padding: 10px 20px;
+    display: inline-block;
+}
+
+.countdown {
+    font-size: 1.5em;
+    margin-top: 10px;
+}
+
+.table-dynasty {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 20px 0;
+}
+
+.table-dynasty th,
+.table-dynasty td {
+    border: 1px solid #d4af37;
+    padding: 8px;
+    text-align: center;
+}
+
+.table-dynasty th {
+    background-color: #222;
+}
+


### PR DESCRIPTION
## Summary
- create `dynastycup-theme` with base styles and header/footer
- add page templates for Home, Partite, Squadre, Regolamento, Risultati
- include countdown script and theme functions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68400d0890c8832599cc6e148d9ef400