### PR TITLE
Imposta scheletro iniziale per portale torneo Flask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+instance/
+.env
+.venv/
+venv/
+*.db
+*.sqlite3
+*.sqlite
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # Primo-progetto
-Il mio primo progetto per testare Codex
+
+Struttura iniziale per un portale di gestione di un torneo di calcio basato su Flask.
+
+## Requisiti
+- Python 3.10+
+- Flask
+- Flask-SQLAlchemy
+
+## Installazione e avvio
+1. Creare ed attivare un ambiente virtuale.
+2. Installare le dipendenze principali:
+   ```bash
+   pip install flask flask-sqlalchemy
+   ```
+3. Avviare l'applicazione:
+   ```bash
+   python run.py
+   ```
+   Il comando crea automaticamente il database SQLite `tournament.db` se non esiste.
+
+La homepage è raggiungibile su `http://localhost:5000/`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,31 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+# Inizializzazione dell'oggetto SQLAlchemy a livello di package
+# per consentire l'utilizzo nei moduli dei modelli e delle view.
+db = SQLAlchemy()
+
+
+def create_app():
+    """Factory per creare e configurare l'app Flask."""
+    app = Flask(
+        __name__,
+        template_folder="../templates",
+        static_folder="../static",
+    )
+
+    # Configurazione di base dell'applicazione e del database SQLite
+    app.config.from_mapping(
+        SQLALCHEMY_DATABASE_URI="sqlite:///tournament.db",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+
+    db.init_app(app)
+
+    # Import locale per registrare modelli e blueprint
+    from app import models  # noqa: F401
+    from app.routes import main_bp
+
+    app.register_blueprint(main_bp)
+
+    return app

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+
+from app import db
+
+
+class Team(db.Model):
+    __tablename__ = "teams"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), unique=True, nullable=False)
+    captain_name = db.Column(db.String(120), nullable=False)
+    captain_email = db.Column(db.String(255), unique=True, nullable=False)
+    creation_date = db.Column(db.DateTime, default=datetime.utcnow)
+
+    players = db.relationship("Player", back_populates="team", cascade="all, delete-orphan")
+    home_matches = db.relationship(
+        "Match",
+        foreign_keys="Match.home_team_id",
+        back_populates="home_team",
+        cascade="all, delete-orphan",
+    )
+    away_matches = db.relationship(
+        "Match",
+        foreign_keys="Match.away_team_id",
+        back_populates="away_team",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - rappresentazione semplice
+        return f"<Team {self.name}>"
+
+
+class Player(db.Model):
+    __tablename__ = "players"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    team_id = db.Column(db.Integer, db.ForeignKey("teams.id"))
+    goals = db.Column(db.Integer, default=0)
+
+    team = db.relationship("Team", back_populates="players")
+
+    def __repr__(self) -> str:  # pragma: no cover - rappresentazione semplice
+        return f"<Player {self.name}>"
+
+
+class Match(db.Model):
+    __tablename__ = "matches"
+
+    id = db.Column(db.Integer, primary_key=True)
+    home_team_id = db.Column(db.Integer, db.ForeignKey("teams.id"))
+    away_team_id = db.Column(db.Integer, db.ForeignKey("teams.id"))
+    match_date = db.Column(db.DateTime)
+    home_team_score = db.Column(db.Integer, default=0)
+    away_team_score = db.Column(db.Integer, default=0)
+    status = db.Column(db.String(50), default="Scheduled")
+
+    home_team = db.relationship("Team", foreign_keys=[home_team_id], back_populates="home_matches")
+    away_team = db.relationship("Team", foreign_keys=[away_team_id], back_populates="away_matches")
+
+    def __repr__(self) -> str:  # pragma: no cover - rappresentazione semplice
+        return f"<Match {self.home_team_id} vs {self.away_team_id}>"

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,9 @@
+from flask import Blueprint, render_template
+
+main_bp = Blueprint("main", __name__)
+
+
+@main_bp.route("/")
+def index():
+    """Homepage basilare dell'applicazione."""
+    return render_template("index.html")

--- a/run.py
+++ b/run.py
@@ -1,0 +1,14 @@
+from app import create_app, db
+
+app = create_app()
+
+
+def setup_database() -> None:
+    """Crea tutte le tabelle se non esistono."""
+    with app.app_context():
+        db.create_all()
+
+
+if __name__ == "__main__":
+    setup_database()
+    app.run(debug=True)

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,18 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f7f7f7;
+    color: #333;
+}
+
+header, footer {
+    background-color: #004aad;
+    color: #fff;
+    text-align: center;
+    padding: 1rem;
+}
+
+main {
+    padding: 2rem;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Benvenuto nel Portale del Torneo</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+    <header>
+        <h1>Benvenuto nel Portale del Torneo</h1>
+    </header>
+    <main>
+        <p>Questa è la homepage iniziale. Ulteriori funzionalità saranno aggiunte in seguito.</p>
+    </main>
+    <footer>
+        <p>&copy; {{ 2024 }} Portale Torneo</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- configura l'app Flask con factory, SQLAlchemy e cartelle standard
- definisce i modelli Team, Player e Match per il database SQLite
- aggiunge homepage di base, foglio di stile e script di avvio per creare le tabelle

## Testing
- python -m compileall app run.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692430af791083259a13b0d147c06272)